### PR TITLE
update to jepsen 0.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.2.8-SNAPSHOT"
+                 [jepsen "0.3.2"
                   ; More jetcd conflicts
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [tech.droit/clj-diff "1.0.1"]


### PR DESCRIPTION
I often use etcd to test when setting up a new environment, e.g. the latest docker.

Recently, tests fail with:
```
java.lang.NoClassDefFoundError: dom-top/core/MutableAcc-Object-Object
```

This Exception also popped up during the history work but went away in other tests.
Guessing some SNAPSHOT interactions?

Upgrading to Jepsen 0.3.2 allows the tests to run.

